### PR TITLE
Remove references to `/report` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ This will trigger questions that take longer to reply, so they're only done week
 
 ```
 skip - Skip a question that was asked
-report - Generate one page report
 track - Track a specific value only
 mood - Track your mood
 awake - First thing in the morning

--- a/worker.js
+++ b/worker.js
@@ -347,7 +347,7 @@ function parseUserInput(ctx, text) {
 function sendAvailableCommands(ctx) {
     ctx.reply("Available commands:").then(function (_a) {
         var message_id = _a.message_id;
-        ctx.reply("\n\n/skip\n/report\n\n/" + Object.keys(config.userConfig).join("\n/"));
+        ctx.reply("\n\n/skip\n\n/" + Object.keys(config.userConfig).join("\n/"));
     });
 }
 function saveLastRun(command) {

--- a/worker.ts
+++ b/worker.ts
@@ -486,7 +486,7 @@ function parseUserInput(ctx, text = null) {
 function sendAvailableCommands(ctx) {
   ctx.reply("Available commands:").then(({ message_id }) => {
     ctx.reply(
-      "\n\n/skip\n/report\n\n/" + Object.keys(config.userConfig).join("\n/")
+      "\n\n/skip\n\n/" + Object.keys(config.userConfig).join("\n/")
     );
   });
 }


### PR DESCRIPTION
The `/report` command was removed in a5c4838, but some references to it in the code still remained. This cleans those references up.