### PR TITLE
Add unique constraint to `last_run.command`

### DIFF
--- a/db/create_tables.sql
+++ b/db/create_tables.sql
@@ -37,6 +37,10 @@ CREATE TABLE last_run (
     last_message bigint
 );
 
+-- Unique constraints required for `last_run` updating
+CREATE UNIQUE INDEX CONCURRENTLY last_run_command_uix ON last_run (command);
+ALTER TABLE last_run ADD CONSTRAINT last_run_command_uc UNIQUE USING INDEX last_run_command_uix;
+
 
 -- View needed for metrics
 


### PR DESCRIPTION
In b19ab98, the updating of the `last_run` table was migrated to Postgres-native logic by using `ON CONFLICT` to perform the update rather than an insert. This is a great change from the parent revision, but requires a unique constraint to be on `last_run.command` so that the update can actually occur.